### PR TITLE
Introduces S3 prefixes for intermediate files

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -14,37 +14,27 @@ The tools below are necessary for setting up the client.
 
 - Python 3.8
 
-## AWS IAM permissions
-Client needs the following IAM permissions to access AWS APIs.
-- `sqs:GetQueueUrl`
-- `sqs:ReceiveMessage`
-- `sqs:DeleteMessage`
-- `s3:GetObject`
-- `s3:PutObject`
-- `state:SendTaskSuccess`
+## Create IAM user for clients
+VFL client program needs IAM credentials to access AWS services. The program accesses Amazon SQS, Amazon S3 and AWS Step Functions APIs. The IAM policy and group are created when [deploying the server](../server/README.md#deploying-the-server).
 
-This is the example policy for client.
+You need to create IAM user and its access key ID and secret access key.\
+It is recommended to create an IAM user for each VFL client. This will prevent the other clients from accessing the intermediate files.
 
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": {
-        "Effect": "Allow",
-        "Action": [
-            "sqs:GetQueueUrl",
-            "sqs:ReceiveMessage",
-            "sqs:DeleteMessage",
-            "s3:GetObject",
-            "s3:PutObject",
-            "states:SendTaskSuccess"
-        ],
-        "Resource": "*"
-    }
-}
+1. [Creating an IAM user in your AWS account](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html)
+1. [Managing access keys for IAM users](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)
+
+Then, add the users to the group to grant access to AWS services.
+- [Add users to group](https://docs.aws.amazon.com/singlesignon/latest/userguide/adduserstogroups.html)
+
+The group name created by [deploying the server](../server/README.md#deploying-the-server) can be found by the following command:
+
+```shell
+STACK_NAME=[STACK_NAME] aws cloudformation describe-stacks --stack-name $STACK_NAME --query 'Stacks[0].Outputs[?OutputKey==`IAMGroupNameForClient`].OutputValue' --output text
 ```
+*STACK_NAME* is a name of the CloudFormation stack. It should be `[STACK_NAME]-IAMGroupForClient-XXXXXXXX`.
 
 
-## Installing the libraries
+## Install the libraries
 1. Clone the repository
     ```shell
     git clone https://github.com/docomoinnovations/AWS-Serverless-Vertical-Federated-Learning
@@ -56,3 +46,8 @@ This is the example policy for client.
     cd client
     pip install -r requirements.txt
     ```
+
+## Configure credentials
+Configure IAM credentials on each VFL client.
+If you configure the credentials with environmet variables, set environment variables bellow:
+- [Configure credentials with environment variables (Boto3)](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#environment-variables)

--- a/client/local_training.py
+++ b/client/local_training.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+import shutil
 import tempfile
 from pathlib import Path
 import numpy as np
@@ -384,13 +385,7 @@ class ClientTrainer:
         )
         key = model_name.split("/")[-1]
         self.s3.meta.client.upload_file(model_name, self.session.s3_bucket, key)
-        os.remove(
-            f"{self.tmp_dir}/{self.session.task_name}-tr-embed-{self.client_id}.npy"
-        )
-        os.remove(
-            f"{self.tmp_dir}/{self.session.task_name}-va-embed-{self.client_id}.npy"
-        )
-        os.remove(f"{self.tmp_dir}/{self.session.task_name}-gradient.npy")
+        shutil.rmtree(self.tmp_dir)
 
 
 if __name__ == "__main__":

--- a/client/local_training.py
+++ b/client/local_training.py
@@ -263,7 +263,7 @@ class ClientTrainer:
         np.save(file_name, self.embed.detach().cpu().numpy(), allow_pickle=False)
         key = file_name.split("/")[-1]
         self.s3.meta.client.upload_file(file_name, bucket, key)
-        return f"s3://{bucket}/{file_name}"
+        return f"s3://{bucket}/{key}"
 
     def __set_gradient(self, s3_uri: str) -> None:
         bucket = s3_uri.split("/")[2]

--- a/client/local_training.py
+++ b/client/local_training.py
@@ -140,11 +140,12 @@ class ShuffledIndex:
         elif uri.startswith("s3://"):
             bucket_name = uri.split("/")[2]
             key = "/".join(uri.split("/")[3:])
+            file_name = uri.split("/")[-1]
             bucket = boto3.resource("s3").Bucket(bucket_name)
             with tempfile.TemporaryDirectory() as tmpdirname:
-                bucket.download_file(key, f"{tmpdirname}/{key}")
+                bucket.download_file(key, f"{tmpdirname}/{file_name}")
                 self.index = torch.LongTensor(
-                    np.load(f"{tmpdirname}/{key}", allow_pickle=False)
+                    np.load(f"{tmpdirname}/{file_name}", allow_pickle=False)
                 )
         else:
             self.index = torch.LongTensor(np.load(uri, allow_pickle=False))

--- a/client/local_training.py
+++ b/client/local_training.py
@@ -390,9 +390,7 @@ class ClientTrainer:
         os.remove(
             f"{self.tmp_dir}/{self.session.task_name}-va-embed-{self.client_id}.npy"
         )
-        os.remove(
-            f"{self.tmp_dir}/{self.session.task_name}-gradient-{self.client_id}.npy"
-        )
+        os.remove(f"{self.tmp_dir}/{self.session.task_name}-gradient.npy")
 
 
 if __name__ == "__main__":

--- a/client/tests/test_local_training.py
+++ b/client/tests/test_local_training.py
@@ -268,10 +268,11 @@ def index(request):
                     for i in range(20)
                 ]
             )
+            key = f"common/{file_name}"
             bucket = boto3.resource("s3").Bucket(bucket_name)
             bucket.create(CreateBucketConfiguration={"LocationConstraint": "us-west-2"})
-            bucket.upload_file(local_path, file_name)
-            yield {"Uri": f"s3://{bucket.name}/{file_name}", "Object": index}
+            bucket.upload_file(local_path, key)
+            yield {"Uri": f"s3://{bucket.name}/{key}", "Object": index}
 
             bucket.objects.all().delete()
             bucket.delete()

--- a/client/tests/test_local_training.py
+++ b/client/tests/test_local_training.py
@@ -7,6 +7,7 @@ import random
 import string
 import json
 from local_training import (
+    S3Url,
     ClientTrainer,
     Dataset,
     VFLSQS,
@@ -14,6 +15,42 @@ from local_training import (
     ClientModel,
     ShuffledIndex,
 )
+
+
+@pytest.mark.parametrize(
+    ("s3_url", "bucket", "key", "prefix", "file_name"),
+    [
+        ("s3://test/example.jpg", "test", "example.jpg", "", "example.jpg"),
+        (
+            "s3://test/prefix/shuffled-index.npy",
+            "test",
+            "prefix/shuffled-index.npy",
+            "prefix/",
+            "shuffled-index.npy",
+        ),
+        (
+            "s3://test.example.com/prefix/shuffled-index.npy",
+            "test.example.com",
+            "prefix/shuffled-index.npy",
+            "prefix/",
+            "shuffled-index.npy",
+        ),
+        (
+            "s3://test.example.com/prefix/test/shuffled-index.npy",
+            "test.example.com",
+            "prefix/test/shuffled-index.npy",
+            "prefix/test/",
+            "shuffled-index.npy",
+        ),
+    ],
+)
+def test_s3_url(s3_url, bucket, key, prefix, file_name):
+    s3_url_obj = S3Url(s3_url)
+    assert s3_url_obj.url == s3_url
+    assert s3_url_obj.bucket == bucket
+    assert s3_url_obj.key == key
+    assert s3_url_obj.prefix == prefix
+    assert s3_url_obj.file_name == file_name
 
 
 @pytest.mark.parametrize(

--- a/server/functions/server_training/server_training.py
+++ b/server/functions/server_training/server_training.py
@@ -460,7 +460,7 @@ def lambda_handler(event, context):
         )
 
         gradient_object = boto3.resource("s3").Object(
-            s3_bucket, f"{url.prefix}{task_name}-gradient.npy"
+            s3_bucket, f"{url.prefix}{task_name}-gradient-{client_id}.npy"
         )
         gradient_value = torch.FloatTensor(np.zeros(embed.value.shape))
         gradient = Gradient(value=gradient_value, s3_object=gradient_object)

--- a/server/template.yaml
+++ b/server/template.yaml
@@ -306,6 +306,11 @@ Resources:
               - !Sub "arn:aws:s3:::${VFLBucket}/common/*"
           - Effect: Allow
             Action:
+              - "s3:PutObject"
+            Resource:
+              - !Sub "arn:aws:s3:::${VFLBucket}/model/*"
+          - Effect: Allow
+            Action:
               - "states:SendTaskSuccess"
             Resource: "*"
 

--- a/server/template.yaml
+++ b/server/template.yaml
@@ -280,7 +280,45 @@ Resources:
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
 
+  IAMPolicyForClient:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Managed policy for VFL client
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "sqs:GetQueueUrl"
+              - "sqs:ReceiveMessage"
+              - "sqs:DeleteMessage"
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - "s3:GetObject"
+              - "s3:PutObject"
+            Resource:
+              - !Sub "arn:aws:s3:::${VFLBucket}/${!aws:userid}/*"
+          - Effect: Allow
+            Action:
+              - "s3:GetObject"
+            Resource:
+              - !Sub "arn:aws:s3:::${VFLBucket}/common/*"
+          - Effect: Allow
+            Action:
+              - "states:SendTaskSuccess"
+            Resource: "*"
+
+  IAMGroupForClient:
+    Type: AWS::IAM::Group
+    Properties:
+      ManagedPolicyArns:
+        - !Ref IAMPolicyForClient
+
 Outputs:
   StateMachineArn:
     Description: The VFL server state machine ARN
     Value: !Ref FederatedLearningMainStateMachine
+  IAMGroupNameForClient:
+    Description: The IAM group name for VFL clients
+    Value: !Ref IAMGroupForClient

--- a/server/tests/test_init_server.py
+++ b/server/tests/test_init_server.py
@@ -120,12 +120,14 @@ def test_set_shuffled_index(bucket):
     task_name = "VFL-TAKS-YYYY-MM-DD-HH-mm-ss"
     dataset = "functions/init_server/tr_uid.npy"
 
-    s3_url = set_shuffled_index(dataset=dataset, task_name=task_name, bucket=bucket)
-    assert s3_url == f"s3://{bucket}/{task_name}-shuffled-index.npy"
-
-    shuffled_index_obj = boto3.resource("s3").Object(
-        bucket, f"{task_name}-shuffled-index.npy"
+    prefix = "common/"
+    key = f"{prefix}{task_name}-shuffled-index.npy"
+    s3_url = set_shuffled_index(
+        dataset=dataset, task_name=task_name, bucket=bucket, prefix=prefix
     )
+    assert s3_url == f"s3://{bucket}/{key}"
+
+    shuffled_index_obj = boto3.resource("s3").Object(bucket, key)
     with tempfile.TemporaryDirectory() as tmpdirname:
         shuffled_index_obj.download_file(f"{tmpdirname}/shuffled-index.npy")
         shuffled_index = torch.LongTensor(

--- a/server/tests/test_server_training.py
+++ b/server/tests/test_server_training.py
@@ -2,14 +2,43 @@ import pytest
 import boto3
 import random
 import string
+import tempfile
 import torch
 import numpy as np
 from functions.server_training.server_training import (
+    S3Url,
+    ShuffledIndex,
     ServerTrainer,
     TrainingSession,
     DataSet,
 )
 from functions.init_server.serverinit import set_shuffled_index
+
+
+@pytest.mark.parametrize(
+    ("s3_url", "bucket", "key", "file_name"),
+    [
+        ("s3://test/example.jpg", "test", "example.jpg", "example.jpg"),
+        (
+            "s3://test/prefix/shuffled-index.npy",
+            "test",
+            "prefix/shuffled-index.npy",
+            "shuffled-index.npy",
+        ),
+        (
+            "s3://test.example.com/prefix/shuffled-index.npy",
+            "test.example.com",
+            "prefix/shuffled-index.npy",
+            "shuffled-index.npy",
+        ),
+    ],
+)
+def test_s3_url(s3_url, bucket, key, file_name):
+    s3_url_obj = S3Url(s3_url)
+    assert s3_url_obj.url == s3_url
+    assert s3_url_obj.bucket == bucket
+    assert s3_url_obj.key == key
+    assert s3_url_obj.file_name == file_name
 
 
 def test_init_dataset():
@@ -60,6 +89,43 @@ def test_init_dataset():
 
 
 @pytest.fixture
+def shuffled_index_url() -> S3Url:
+    bucket_name = "".join(
+        [random.choice(string.ascii_lowercase + string.digits) for i in range(20)]
+    )
+
+    bucket = boto3.resource("s3").Bucket(bucket_name)
+    bucket.create(CreateBucketConfiguration={"LocationConstraint": "us-west-2"})
+
+    shuffled_index_url = set_shuffled_index(
+        "functions/init_server/tr_uid.npy",
+        "VFL-TAKS-YYYY-MM-DD-HH-mm-ss",
+        bucket.name,
+        prefix="common/",
+    )
+
+    yield S3Url(shuffled_index_url)
+
+    bucket.objects.all().delete()
+    bucket.delete()
+
+
+def test_shuffled_index(shuffled_index_url: S3Url):
+    shuffled_index = ShuffledIndex(shuffled_index_url)
+    bucket = shuffled_index_url.bucket
+    key = shuffled_index_url.key
+    file_name = shuffled_index_url.file_name
+    shuffled_index_obj = boto3.resource("s3").Object(bucket, key)
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        shuffled_index_obj.download_file(f"{tmpdirname}/{file_name}")
+        donwloaded_shuffled_index = torch.LongTensor(
+            np.load(f"{tmpdirname}/{file_name}", allow_pickle=False)
+        )
+        assert shuffled_index.s3_url == shuffled_index_url
+        assert shuffled_index.index.tolist() == donwloaded_shuffled_index.tolist()
+
+
+@pytest.fixture
 def bucket_name() -> str:
     bucket_name = "".join(
         [random.choice(string.ascii_lowercase + string.digits) for i in range(20)]
@@ -69,10 +135,34 @@ def bucket_name() -> str:
     bucket.create(CreateBucketConfiguration={"LocationConstraint": "us-west-2"})
 
     set_shuffled_index(
-        f"functions/init_server/tr_uid.npy", "VFL-TAKS-YYYY-MM-DD-HH-mm-ss", bucket.name
+        "functions/init_server/tr_uid.npy",
+        "VFL-TAKS-YYYY-MM-DD-HH-mm-ss",
+        bucket.name,
+        prefix="common/",
     )
 
     yield bucket.name
+
+    bucket.objects.all().delete()
+    bucket.delete()
+
+
+@pytest.fixture
+def shuffled_index() -> ShuffledIndex:
+    bucket_name = "".join(
+        [random.choice(string.ascii_lowercase + string.digits) for i in range(20)]
+    )
+
+    bucket = boto3.resource("s3").Bucket(bucket_name)
+    bucket.create(CreateBucketConfiguration={"LocationConstraint": "us-west-2"})
+    s3_url = set_shuffled_index(
+        "functions/init_server/tr_uid.npy",
+        "VFL-TAKS-YYYY-MM-DD-HH-mm-ss",
+        bucket.name,
+        prefix="common/",
+    )
+
+    yield ShuffledIndex(S3Url(s3_url))
 
     bucket.objects.all().delete()
     bucket.delete()
@@ -105,6 +195,7 @@ def test_training_session(
     batch_index,
     batch_size,
     va_batch_index,
+    shuffled_index,
 ):
     session = TrainingSession(
         task_name=task_name,
@@ -113,6 +204,7 @@ def test_training_session(
         batch_index=batch_index,
         batch_size=batch_size,
         va_batch_index=va_batch_index,
+        shuffled_index=shuffled_index,
     )
     assert session.task_name == task_name
     assert session.num_of_clients == num_of_clients
@@ -120,22 +212,38 @@ def test_training_session(
     assert session.batch_index == batch_index
     assert session.batch_size == batch_size
     assert session.va_batch_index == va_batch_index
+    assert session.shuffled_index.tolist() == shuffled_index.index.tolist()
 
 
 @pytest.mark.parametrize(
-    ("training_session"),
+    (
+        "task_name",
+        "num_of_clients",
+        "epoch_index",
+        "batch_index",
+        "batch_size",
+        "va_batch_index",
+    ),
     [
-        TrainingSession(
-            task_name="VFL-TAKS-YYYY-MM-DD-HH-mm-ss",
-            num_of_clients=4,
-            epoch_index=0,
-            batch_index=0,
-            batch_size=1024,
-            va_batch_index=0,
+        (
+            "VFL-TAKS-YYYY-MM-DD-HH-mm-ss",
+            4,
+            0,
+            0,
+            1024,
+            0,
         )
     ],
 )
-def test_init_server_trainer(training_session, bucket_name):
+def test_init_server_trainer(
+    task_name,
+    num_of_clients,
+    epoch_index,
+    batch_index,
+    batch_size,
+    va_batch_index,
+    shuffled_index,
+):
     dataset_dir = "functions/server_training"
     label = f"{dataset_dir}/tr_y.npy"
     uid = f"{dataset_dir}/tr_uid.npy"
@@ -143,6 +251,15 @@ def test_init_server_trainer(training_session, bucket_name):
     va_uid = f"{dataset_dir}/va_uid.npy"
 
     dataset = DataSet(label=label, uid=uid, va_label=va_label, va_uid=va_uid)
+    training_session = TrainingSession(
+        task_name=task_name,
+        num_of_clients=num_of_clients,
+        epoch_index=epoch_index,
+        batch_index=batch_index,
+        batch_size=batch_size,
+        va_batch_index=va_batch_index,
+        shuffled_index=shuffled_index,
+    )
 
     server_trainer = ServerTrainer(
         training_session=training_session, s3_bucket=bucket_name, dataset=dataset
@@ -161,3 +278,7 @@ def test_init_server_trainer(training_session, bucket_name):
     assert len(server_trainer.tr_uid) == len(dataset.uid)
     assert len(server_trainer.va_y) == len(dataset.va_label)
     assert len(server_trainer.va_uid) == len(dataset.va_uid)
+    assert (
+        server_trainer.shuffled_index.tolist()
+        == training_session.shuffled_index.tolist()
+    )

--- a/server/tests/test_server_training.py
+++ b/server/tests/test_server_training.py
@@ -346,11 +346,13 @@ def test_init_server_trainer(
         loss=loss,
     )
     model = ServerModel(4 * num_of_clients, 1)
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
 
     server_trainer = ServerTrainer(
         training_session=training_session,
         s3_bucket=bucket_name,
         model=model,
+        optimizer=optimizer,
         dataset=dataset,
     )
     assert server_trainer.task_name == training_session.task_name
@@ -374,3 +376,4 @@ def test_init_server_trainer(
     assert server_trainer.loss.total_tr_loss == loss.total_tr_loss
     assert server_trainer.loss.total_va_loss == loss.total_va_loss
     assert len(server_trainer.model.state_dict()) == len(model.state_dict())
+    assert len(server_trainer.optimizer.state_dict()) == len(optimizer.state_dict())

--- a/server/tests/test_server_training.py
+++ b/server/tests/test_server_training.py
@@ -271,9 +271,23 @@ def shuffled_index() -> ShuffledIndex:
         "batch_index",
         "batch_size",
         "va_batch_index",
+        "tr_pred",
+        "va_pred",
         "loss",
     ),
-    [("VFL-TAKS-YYYY-MM-DD-HH-mm-ss", 4, 0, 0, 1024, 0, Loss())],
+    [
+        (
+            "VFL-TAKS-YYYY-MM-DD-HH-mm-ss",
+            4,
+            0,
+            0,
+            1024,
+            0,
+            np.zeros([29304, 1]),
+            np.zeros([3257, 1]),
+            Loss(),
+        ),
+    ],
 )
 def test_training_session(
     task_name,
@@ -283,6 +297,8 @@ def test_training_session(
     batch_size,
     va_batch_index,
     shuffled_index,
+    tr_pred,
+    va_pred,
     loss,
 ):
     session = TrainingSession(
@@ -293,6 +309,8 @@ def test_training_session(
         batch_size=batch_size,
         va_batch_index=va_batch_index,
         shuffled_index=shuffled_index,
+        tr_pred=tr_pred,
+        va_pred=va_pred,
         loss=loss,
     )
     assert session.task_name == task_name
@@ -302,6 +320,8 @@ def test_training_session(
     assert session.batch_size == batch_size
     assert session.va_batch_index == va_batch_index
     assert session.shuffled_index.tolist() == shuffled_index.index.tolist()
+    assert np.all(session.tr_pred == tr_pred)
+    assert np.all(session.va_pred == va_pred)
     assert session.loss.total_tr_loss == loss.total_tr_loss
     assert session.loss.total_va_loss == loss.total_va_loss
 
@@ -314,9 +334,23 @@ def test_training_session(
         "batch_index",
         "batch_size",
         "va_batch_index",
+        "tr_pred",
+        "va_pred",
         "loss",
     ),
-    [("VFL-TAKS-YYYY-MM-DD-HH-mm-ss", 4, 0, 0, 1024, 0, Loss())],
+    [
+        (
+            "VFL-TAKS-YYYY-MM-DD-HH-mm-ss",
+            4,
+            0,
+            0,
+            1024,
+            0,
+            np.zeros([29304, 1]),
+            np.zeros([3257, 1]),
+            Loss(),
+        )
+    ],
 )
 def test_init_server_trainer(
     task_name,
@@ -325,6 +359,8 @@ def test_init_server_trainer(
     batch_index,
     batch_size,
     va_batch_index,
+    tr_pred,
+    va_pred,
     loss,
     shuffled_index,
 ):
@@ -343,6 +379,8 @@ def test_init_server_trainer(
         batch_size=batch_size,
         va_batch_index=va_batch_index,
         shuffled_index=shuffled_index,
+        tr_pred=tr_pred,
+        va_pred=va_pred,
         loss=loss,
     )
     model = ServerModel(4 * num_of_clients, 1)
@@ -373,6 +411,8 @@ def test_init_server_trainer(
         server_trainer.shuffled_index.tolist()
         == training_session.shuffled_index.tolist()
     )
+    assert np.all(server_trainer.tr_pred == tr_pred)
+    assert np.all(server_trainer.va_pred == va_pred)
     assert server_trainer.loss.total_tr_loss == loss.total_tr_loss
     assert server_trainer.loss.total_va_loss == loss.total_va_loss
     assert len(server_trainer.model.state_dict()) == len(model.state_dict())

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -58,10 +58,12 @@ def download_models(s3_bucket, task_name, num_of_clients):
     s3 = boto3.resource("s3")
     bucket = s3.Bucket(s3_bucket)
     server_model = f"{task_name}-server-model-best.pt"
-    bucket.download_file(server_model, server_model)
+    server_model_key = f"model/{server_model}"
+    bucket.download_file(server_model_key, server_model)
     for i in range(num_of_clients):
         client_model = f"{task_name}-client-model-{i+1}-best.pt"
-        bucket.download_file(client_model, client_model)
+        client_model_key = f"model/{client_model}"
+        bucket.download_file(client_model_key, client_model)
 
 
 seed = 42


### PR DESCRIPTION
Introduces the following S3 prefixes for intermediate files

- `server`
  Only server is able to write/read and client is not able to write/read. The intermediate files related to server training are stored under the prefix.
- `common`
  Server is able to write/read and client is able to read only. 
- `${aws:userid}`
  Server is able to write/read. Client is able to write/read under its userid prefix only. 